### PR TITLE
Add python-dev to rebuild auction ruby image

### DIFF
--- a/base_images/ruby_2_7/Dockerfile
+++ b/base_images/ruby_2_7/Dockerfile
@@ -53,6 +53,7 @@ RUN apt-get install -y --no-install-recommends > /dev/null \
   wkhtmltopdf \
   libxslt1-dev \
   libxml2-dev \
+  python-dev \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Related to #13

This PR is just to save changes now in dockerhub for ruby:2.7 image.