### PR TITLE
fixed db environment setup docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,9 +162,9 @@ services:
       - "5433:5432"
     restart: always
     environment:
-      POSTGRES_PASSWORD: password
-      POSTGRES_DB: "db"
-      POSTGRES_HOST_AUTH_METHOD: "trust"
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=db
+      - POSTGRES_HOST_AUTH_METHOD=trust
 
 volumes:
   pg:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,12 +158,11 @@ services:
     image: postgres:9.6.21
     volumes:
       - pg:/var/lib/postgresql/data
-    environment:
-      - POSTGRES_PASSWORD=password
     ports:
       - "5433:5432"
     restart: always
     environment:
+      POSTGRES_PASSWORD: password
       POSTGRES_DB: "db"
       POSTGRES_HOST_AUTH_METHOD: "trust"
 


### PR DESCRIPTION
Fixes #31 

Newer Docker Compose will fail to build docker images if there are duplicate propertie fields on docker-compose because variables from last set may overwrite previous set and building a container will give an 'yaml. unmarshal error'

Compiled duplicates 'environment' for db: in docker-compose.yml and used uniform format.